### PR TITLE
Refactor builtins

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -159,17 +159,17 @@ typedef struct s_ast
 /* =========================== */
 
 /* src/builtins/pwd.c */
-int			builtin_pwd(char **tokens, t_shell *data);
+int			builtin_pwd(char **argv, t_shell *data);
 
 /* src/builtins/cd.c */
-int			builtin_cd(char **tokens, t_shell *data);
+int			builtin_cd(char **argv, t_shell *data);
 
 /* src/builtins/env.c */
-int			builtin_env(char **tokens, t_shell *data);
+int			builtin_env(char **argv, t_shell *data);
 
 /* src/builtins/export.c */
-int			set_env_node(t_list **env_list, const char *token);
-int			builtin_export(char **tokens, t_shell *data);
+int			set_env_node(t_list **env_list, const char *arg);
+int			builtin_export(char **argv, t_shell *data);
 
 /* src/builtins/export_array.c */
 t_env		**export_list_to_array(t_list *list, int *size);
@@ -186,29 +186,29 @@ void		swap_env(t_env **a, t_env **b);
 int			partition(t_env **array, int low, int high);
 
 /* src/export_update.c */
-t_env		*create_new_env_node(char *key, const char *token, t_export_op op);
-int			update_existing_env_node(t_env *env_node, const char *token);
-int			append_env_value(t_env *env_node, const char *token);
+t_env		*create_new_env_node(char *key, const char *arg, t_export_op op);
+int			update_existing_env_node(t_env *env_node, const char *arg);
+int			append_env_value(t_env *env_node, const char *arg);
 
 /* src/builtins/export_utils.c */
-t_export_op	detect_operation(const char *token);
-bool		is_valid_key(const char *token);
-char		*get_env_key(const char *token);
-char		*get_env_value(const char *token);
+t_export_op	detect_operation(const char *arg);
+bool		is_valid_key(const char *arg);
+char		*get_env_key(const char *arg);
+char		*get_env_value(const char *arg);
 t_env		*get_env_node_by_key(t_list *env_list, const char *key);
 
 /* src/builtins/echo.c */
-int			builtin_echo(char **tokens, t_shell *data);
+int			builtin_echo(char **argv, t_shell *data);
 
 /* src/builtins/exit.c */
-int			builtin_exit(char **tokens, t_shell *data);
+int			builtin_exit(char **argv, t_shell *data);
 
 /* src/builtins/unset.c */
-int			remove_env_node(t_list **env_list, const char *token);
-int			builtin_unset(char **tokens, t_shell *data);
+int			remove_env_node(t_list **env_list, const char *arg);
+int			builtin_unset(char **argv, t_shell *data);
 
 /* src/builtins/execute_builtins.c */
-bool		execute_builtin(char **tokens, t_shell *data);
+bool		execute_builtin(t_ast *list, t_shell *data);
 
 /* =========================== */
 /*     ENVIRONMENT IMPORT      */

--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -3,22 +3,22 @@
 /**
  * @brief Determine the target path for the cd command.
  *
- * Evaluates the command tokens to figure out where cd should navigate:
+ * Evaluates the command argv to figure out where cd should navigate:
  * - No arguments: returns the value of the HOME environment variable.
  * - One argument: returns that argument as the target path.
  * - More than one argument: prints an error and returns NULL.
  *
  * This function does not modify the current working directory itself.
  *
- * @param tokens Array of command tokens, where tokens[0] is "cd".
+ * @param argv Array of command argv, where argv[0] is "cd".
  * @param data Shell data structure containing environment list.
  * @return Pointer to target path string, or NULL on error.
  */
-static char	*get_cd_target(char **tokens, t_shell *data)
+static char	*get_cd_target(char **argv, t_shell *data)
 {
 	t_env	*home_node;
 
-	if (tokens[1] == NULL)
+	if (argv[1] == NULL)
 	{
 		home_node = get_env_node_by_key(data->env_list, "HOME");
 		if (!home_node || !home_node->value)
@@ -28,12 +28,12 @@ static char	*get_cd_target(char **tokens, t_shell *data)
 		}
 		return (home_node->value);
 	}
-	else if (tokens[2] != NULL)
+	else if (argv[2] != NULL)
 	{
 		print_error(ERR_PREFIX, ERR_CD, ERR_TOO_MANY_ARGS, NULL);
 		return (NULL);
 	}
-	return (tokens[1]);
+	return (argv[1]);
 }
 
 /**
@@ -101,16 +101,16 @@ static int	set_status(t_shell *data, int status)
  * Updates OLDPWD in the environment if applicable.
  * Updates the shell status in data->status before returning.
  *
- * @param tokens Command tokens array where tokens[0] is "cd"
+ * @param argv Command argv array where argv[0] is "cd"
  * @param data Shell data structure, including environment and status
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure
  */
-int	builtin_cd(char **tokens, t_shell *data)
+int	builtin_cd(char **argv, t_shell *data)
 {
 	char	*target;
 	char	*oldpwd;
 
-	if (!tokens || !data)
+	if (!argv || !data)
 		return (set_status(data, EXIT_FAILURE));
 	oldpwd = getcwd(NULL, 0);
 	if (!oldpwd)
@@ -118,7 +118,7 @@ int	builtin_cd(char **tokens, t_shell *data)
 		perror("[mini$HELL: cd: ");
 		return (set_status(data, EXIT_FAILURE));
 	}
-	target = get_cd_target(tokens, data);
+	target = get_cd_target(argv, data);
 	if (!target)
 	{
 		free(oldpwd);

--- a/src/builtins/echo.c
+++ b/src/builtins/echo.c
@@ -1,24 +1,24 @@
 #include "minishell.h"
 
 /**
- * @brief Check if token is a valid bash style -n option for echo.
+ * @brief Check if arg is a valid bash style -n option for echo.
  *
  * Accepts "-n", "-nn", "-nnn", etc. but rejects "-na", "-n1", etc.
  * Implements bash's quirky but exact -n recognition behavior.
  *
- * @param token String to check
+ * @param arg String to check
  * @return true if valid -n option, false otherwise
  */
-static bool	is_echo_n_option(const char *token)
+static bool	is_echo_n_option(const char *arg)
 {
 	int	i;
 
-	if (!token || token[0] != '-' || token[1] != 'n')
+	if (!arg || arg[0] != '-' || arg[1] != 'n')
 		return (false);
 	i = 2;
-	while (token[i])
+	while (arg[i])
 	{
-		if (token[i] != 'n')
+		if (arg[i] != 'n')
 			return (false);
 		i++;
 	}
@@ -26,20 +26,20 @@ static bool	is_echo_n_option(const char *token)
 }
 
 /**
- * @brief Print tokens starting at given index, space separated.
+ * @brief Print argv starting at given index, space separated.
  *
- * Prints each token with single spaces between them (no space after last).
+ * Prints each arg with single spaces between them (no space after last).
  * Helper function for echo output formatting.
  *
- * @param tokens NULL-terminated array of strings
+ * @param argv NULL-terminated array of strings
  * @param start_index Index to start printing from
  */
-static void	print_echo_cmd(char **tokens, int start_print_index)
+static void	print_echo_cmd(char **argv, int start_print_index)
 {
-	while (tokens[start_print_index] != NULL)
+	while (argv[start_print_index] != NULL)
 	{
-		printf("%s", tokens[start_print_index]);
-		if (tokens[start_print_index + 1])
+		printf("%s", argv[start_print_index]);
+		if (argv[start_print_index + 1])
 			printf(" ");
 		start_print_index++;
 	}
@@ -63,16 +63,16 @@ static void	print_echo_cmd(char **tokens, int start_print_index)
  * The -n option is only effective when it appears consecutively at the
  * beginning of the argument list.
  *
- * @param tokens Command tokens array where tokens[0] is "echo"
+ * @param argv Command argv array where argv[0] is "echo"
  * @param data Shell data structure (unused in this builtin)
  * @return Always returns EXIT_SUCCESS (0), updates `data->status`.
  */
-int	builtin_echo(char **tokens, t_shell *data)
+int	builtin_echo(char **argv, t_shell *data)
 {
 	int		start_print_index;
 	bool	print_new_line;
 
-	if (tokens[1] == NULL)
+	if (argv[1] == NULL)
 	{
 		printf("\n");
 		data->status = EXIT_SUCCESS;
@@ -80,13 +80,13 @@ int	builtin_echo(char **tokens, t_shell *data)
 	}
 	start_print_index = 1;
 	print_new_line = true;
-	while (tokens[start_print_index]
-		&& is_echo_n_option(tokens[start_print_index]))
+	while (argv[start_print_index]
+		&& is_echo_n_option(argv[start_print_index]))
 	{
 		print_new_line = false;
 		start_print_index++;
 	}
-	print_echo_cmd(tokens, start_print_index);
+	print_echo_cmd(argv, start_print_index);
 	if (print_new_line)
 		printf("\n");
 	data->status = EXIT_SUCCESS;

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -8,15 +8,15 @@
  * (INTERNAL_ERROR).
  * Updates `data->status` with the command's exit code.
  *
- * @param tokens Command tokens from user input.
- *               - tokens[0] should be "env"
- *               - tokens[1+] triggers "too many arguments" error
+ * @param argv Command argv from user input.
+ *               - argv[0] should be "env"
+ *               - argv[1+] triggers "too many arguments" error
  * @param data Shell state, including environment and exit status.
  * @return Exit status of the command (0 on success, >0 on failure).
  */
-int	builtin_env(char **tokens, t_shell *data)
+int	builtin_env(char **argv, t_shell *data)
 {
-	if (tokens && tokens[1])
+	if (argv && argv[1])
 	{
 		print_error(ERR_PREFIX, ERR_ENV, ERR_TOO_MANY_ARGS, NULL);
 		data->status = MISUSAGE_ERROR;

--- a/src/builtins/execute_builtins.c
+++ b/src/builtins/execute_builtins.c
@@ -7,11 +7,11 @@
  * including `exit`. If a match is found, executes the corresponding
  * function and updates `data->status`. Does not execute external commands.
  *
- * @param tokens Command tokens from user input.
+ * @param argv Command argv from user input.
  * @param data Shell state, including environment, exit status, and exit flag.
  * @return true if the command is a builtin and was executed; false otherwise.
  */
-bool	execute_builtin(char **tokens, t_shell *data)
+bool	execute_builtin(t_ast *list, t_shell *data)
 {
 	int						i;
 	static const t_builtin	builtins[] = {
@@ -21,14 +21,14 @@ bool	execute_builtin(char **tokens, t_shell *data)
 	{"cd", builtin_cd},
 	{NULL, NULL}};
 
-	if (!tokens || !tokens[0])
+	if (!list || !list->argv[0])
 		return (false);
 	i = 0;
 	while (builtins[i].cmd != NULL)
 	{
-		if (ft_strcmp(tokens[0], builtins[i].cmd) == 0)
+		if (ft_strcmp(list->value, builtins[i].cmd) == 0)
 		{
-			builtins[i].f(tokens, data);
+			builtins[i].f(list->argv, data);
 			return (true);
 		}
 		i++;

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -63,24 +63,24 @@ static int	handle_exit_invalid_arg(char *arg, t_shell *data)
  * Handles invalid numeric arguments and too many arguments.
  * If running in a child process, exits immediately.
  *
- * @param tokens Command tokens from user input.
- *               - tokens[0] should be "exit"
- *               - tokens[1] (optional) numeric exit code
- *               - tokens[2+] triggers "too many arguments" error
+ * @param argv Command argv from user input.
+ *               - argv[0] should be "exit"
+ *               - argv[1] (optional) numeric exit code
+ *               - argv[2+] triggers "too many arguments" error
  * @param data Shell state, including exit status, TTY flags, and exit flag.
  * @return Exit status to store in `data->status`.
  */
-int	builtin_exit(char **tokens, t_shell *data)
+int	builtin_exit(char **argv, t_shell *data)
 {
 	long long	exit_code;
 
 	if (data->is_tty && !data->is_child)
 		printf("exit\n");
-	if (tokens[1] == NULL)
+	if (argv[1] == NULL)
 		return (handle_exit_no_args(data));
-	if (ft_safe_atoll(tokens[1], &exit_code) != 1)
-		return (handle_exit_invalid_arg(tokens[1], data));
-	if (tokens[2] != NULL)
+	if (ft_safe_atoll(argv[1], &exit_code) != 1)
+		return (handle_exit_invalid_arg(argv[1], data));
+	if (argv[2] != NULL)
 		return (handle_exit_too_many_args(data));
 	data->status = (unsigned char)(exit_code);
 	if (data->is_child)

--- a/src/builtins/export_update.c
+++ b/src/builtins/export_update.c
@@ -4,21 +4,21 @@
  * @brief Create a new environment variable node.
  *
  * Allocates and initializes a new t_env struct with the given key
- * and the value extracted from the token (if applicable).
+ * and the value extracted from the arg (if applicable).
  *
- * - If `op == EXPORT_ASSIGN`, the value is parsed from the token and
+ * - If `op == EXPORT_ASSIGN`, the value is parsed from the arg and
  *   stored in the node, and `in_env` is set to true.
  * - Otherwise, the node is created without a value and `in_env` is set to
  *   false.
  *
  * @param key   A malloc'ed key string (ownership is transferred to the node).
- * @param token The input string containing the assignment.
+ * @param arg The input string containing the assignment.
  * @param op    The detected export operation (assign, append, or none).
  *
  * @return Pointer to the newly created t_env node, or NULL on malloc failure.
  *         On failure, the provided key is freed.
  */
-t_env	*create_new_env_node(char *key, const char *token, t_export_op op)
+t_env	*create_new_env_node(char *key, const char *arg, t_export_op op)
 {
 	t_env	*new;
 
@@ -28,7 +28,7 @@ t_env	*create_new_env_node(char *key, const char *token, t_export_op op)
 	new->key = key;
 	if (op == EXPORT_ASSIGN)
 	{
-		new->value = get_env_value(token);
+		new->value = get_env_value(arg);
 		if (!new->value)
 		{
 			free(new->key);
@@ -48,22 +48,22 @@ t_env	*create_new_env_node(char *key, const char *token, t_export_op op)
 /**
  * @brief Replace the value of an existing environment variable.
  *
- * Extracts the value from the given token and assigns it to the
+ * Extracts the value from the given arg and assigns it to the
  * environment node, freeing the previous value. The variable is
  * also marked as exported (`in_env = true`).
  *
  * @param env_node The environment node to update.
- * @param token    The input string containing the new assignment.
+ * @param arg    The input string containing the new assignment.
  *
  * @return 1 on success, 0 on failure.
  */
-int	update_existing_env_node(t_env *env_node, const char *token)
+int	update_existing_env_node(t_env *env_node, const char *arg)
 {
 	char	*new_value;
 
-	if (!env_node || !token)
+	if (!env_node || !arg)
 		return (0);
-	new_value = get_env_value(token);
+	new_value = get_env_value(arg);
 	if (!new_value)
 	{
 		errno = ENOMEM;
@@ -79,26 +79,26 @@ int	update_existing_env_node(t_env *env_node, const char *token)
  * @brief Append a new value to an existing environment variable.
  *
  * This function handles the `VAR+=value` case in `export`. It retrieves the
- * value from the given token and concatenates it to the current value of the
+ * value from the given arg and concatenates it to the current value of the
  * environment variable. If the variable has no value yet, the new value is
  * simply assigned.
  *
  * @param env_node Pointer to the existing environment variable node.
- * @param token    The input token (e.g. "VAR+=value").
+ * @param arg    The input arg (e.g. "VAR+=value").
  *
  * @return 1 on success, 0 on failure (malloc error or invalid input).
  *
  * @note Frees and replaces the old `env_node->value` with the appended result.
  */
-int	append_env_value(t_env *env_node, const char *token)
+int	append_env_value(t_env *env_node, const char *arg)
 {
 	char	*new_value;
 	char	*old_value;
 	char	*appended;
 
-	if (!env_node || !token)
+	if (!env_node || !arg)
 		return (0);
-	new_value = get_env_value(token);
+	new_value = get_env_value(arg);
 	if (!new_value)
 		return (0);
 	if (env_node->value)

--- a/src/builtins/export_utils.c
+++ b/src/builtins/export_utils.c
@@ -1,36 +1,36 @@
 #include "minishell.h"
 
 /**
- * @brief Detects the type of export operation in a token.
+ * @brief Detects the type of export operation in a arg.
  *
  * Scans the input string to determine whether it represents:
  * - No operation (`EXPORT_NONE`) if there is no '=' or '+=' present.
  * - Assignment (`EXPORT_ASSIGN`) if there is a '=' not preceded by '+'.
  * - Append (`EXPORT_APPEND`) if there is a '+=' sequence.
  *
- * @param token The input string to analyze.
+ * @param arg The input string to analyze.
  * @return The detected export operation as a t_export_op enum value.
  */
-t_export_op	detect_operation(const char *token)
+t_export_op	detect_operation(const char *arg)
 {
 	int	i;
 
-	if (!token)
+	if (!arg)
 		return (EXPORT_NONE);
 	i = 0;
-	while (token[i] && token[i] != '=' && token[i] != '+')
+	while (arg[i] && arg[i] != '=' && arg[i] != '+')
 		i++;
-	if (token[i] == '\0')
+	if (arg[i] == '\0')
 		return (EXPORT_NONE);
-	if (token[i] == '=')
+	if (arg[i] == '=')
 		return (EXPORT_ASSIGN);
-	if (token[i] == '+' && token[i + 1] && token[i + 1] == '=')
+	if (arg[i] == '+' && arg[i + 1] && arg[i + 1] == '=')
 		return (EXPORT_APPEND);
 	return (EXPORT_ASSIGN);
 }
 
 /**
- * @brief Checks if a given token is a valid shell environment variable key.
+ * @brief Checks if a given arg is a valid shell environment variable key.
  *
  * A valid key must:
  *  - Not be NULL or empty
@@ -38,22 +38,22 @@ t_export_op	detect_operation(const char *token)
  *  - Contain only alphanumeric characters (a-z, A-Z, 0-9) or underscores (_)
  *    up to an optional '=' or '+' character.
  *
- * @param token The input string representing the token to validate.
- * @return true if the token is a valid key according to the rules, false
+ * @param arg The input string representing the arg to validate.
+ * @return true if the arg is a valid key according to the rules, false
  * otherwise.
  */
-bool	is_valid_key(const char *token)
+bool	is_valid_key(const char *arg)
 {
 	int	i;
 
-	if (!token || token[0] == '\0')
+	if (!arg || arg[0] == '\0')
 		return (false);
-	if (!ft_isalpha(token[0]) && token[0] != '_')
+	if (!ft_isalpha(arg[0]) && arg[0] != '_')
 		return (false);
 	i = 1;
-	while (token[i] && token[i] != '=' && token[i] != '+')
+	while (arg[i] && arg[i] != '=' && arg[i] != '+')
 	{
-		if (!ft_isalnum(token[i]) && token[i] != '_')
+		if (!ft_isalnum(arg[i]) && arg[i] != '_')
 			return (false);
 		i++;
 	}
@@ -61,28 +61,28 @@ bool	is_valid_key(const char *token)
 }
 
 /**
- * @brief Extracts the key part from an environment token.
+ * @brief Extracts the key part from an environment arg.
  *
  * Scans the input string until the first '=' or '+' character (for append
  * operations), returning a newly allocated string containing only the key.
- * If the token is invalid, returns NULL. If memory allocation fails,
+ * If the arg is invalid, returns NULL. If memory allocation fails,
  * sets errno to ENOMEM and returns NULL, allowing the caller to distinguish
  * between invalid keys and malloc failure.*
  *
- * @param token Input string in the form KEY=VALUE, KEY+=VALUE, or KEY.
+ * @param arg Input string in the form KEY=VALUE, KEY+=VALUE, or KEY.
  *
  * @return A malloc'ed copy of the key, or NULL if the key is invalid or on
  * malloc failure. Caller is responsible for freeing the returned string.
  */
-char	*get_env_key(const char *token)
+char	*get_env_key(const char *arg)
 {
 	char	*key;
 	int		len;
 
-	if (!is_valid_key(token))
+	if (!is_valid_key(arg))
 		return (NULL);
 	len = 0;
-	while (token[len] && token[len] != '+' && token[len] != '=')
+	while (arg[len] && arg[len] != '+' && arg[len] != '=')
 		len++;
 	key = malloc(len + 1);
 	if (!key)
@@ -90,27 +90,27 @@ char	*get_env_key(const char *token)
 		errno = ENOMEM;
 		return (NULL);
 	}
-	ft_strlcpy(key, token, len + 1);
+	ft_strlcpy(key, arg, len + 1);
 	return (key);
 }
 
 /**
- * @brief Extract the value part from a token (after '=').
+ * @brief Extract the value part from a arg (after '=').
  *
- * @param token Input string in the form KEY=VALUE.
+ * @param arg Input string in the form KEY=VALUE.
  *
  * @return A malloc'ed copy of the value, or NULL if no '=' found or malloc
  * fails.
  *         Caller must free the returned string.
  */
-char	*get_env_value(const char *token)
+char	*get_env_value(const char *arg)
 {
 	char	*value;
 	char	*equal;
 
-	if (!token)
+	if (!arg)
 		return (NULL);
-	equal = ft_strchr(token, '=');
+	equal = ft_strchr(arg, '=');
 	if (!equal)
 		return (NULL);
 	value = ft_strdup(equal + 1);

--- a/src/builtins/pwd.c
+++ b/src/builtins/pwd.c
@@ -7,18 +7,18 @@
 * Uses getcwd() system call to get the real current directory, ignoring
 * the $PWD environment variable (like bash does).
 *
-* @param tokens Command arguments (unused, pwd takes no arguments)
+* @param argv Command arguments (unused, pwd takes no arguments)
 * @param data Shell structure with infos (unused as well)
 * @return Exit status of the command (0 on success, 1 on failure).
 *
 * @note Memory is automatically allocated by getcwd(NULL, 0) and freed
 * @note Errors are handled with perror() which displays appropriate message
 */
-int	builtin_pwd(char **tokens, t_shell *data)
+int	builtin_pwd(char **argv, t_shell *data)
 {
 	char	*path;
 
-	(void)tokens;
+	(void)argv;
 	path = getcwd(NULL, 0);
 	if (!path)
 	{

--- a/src/builtins/unset.c
+++ b/src/builtins/unset.c
@@ -32,7 +32,7 @@ static void	free_env_node(t_env *env_node, t_list *list_node)
  * @return int 0 if a node was found and removed,
  *             1 if the key was not found or list/env_list/key is NULL.
  */
-int	remove_env_node(t_list **env_list, const char *token)
+int	remove_env_node(t_list **env_list, const char *arg)
 {
 	t_list	*prev;
 	t_list	*curr;
@@ -40,12 +40,12 @@ int	remove_env_node(t_list **env_list, const char *token)
 
 	prev = NULL;
 	curr = *env_list;
-	if (!env_list || !*env_list || !token)
+	if (!env_list || !*env_list || !arg)
 		return (1);
 	while (curr)
 	{
 		env = (t_env *)curr->content;
-		if (env && env->key && ft_strcmp(env->key, token) == 0)
+		if (env && env->key && ft_strcmp(env->key, arg) == 0)
 		{
 			if (prev)
 				prev->next = curr->next;
@@ -64,33 +64,33 @@ int	remove_env_node(t_list **env_list, const char *token)
  * @brief Builtin command: remove environment variables.
  *
  * Removes the specified environment variables from `data->env_list`.
- * Ignores tokens containing '='. Updates `data->status` with EXIT_SUCCESS
+ * Ignores argv containing '='. Updates `data->status` with EXIT_SUCCESS
  * on success, or INTERNAL_ERROR if input is invalid.
  *
- * @param tokens Command tokens from user input.
- *               - tokens[0] should be "unset"
- *               - tokens[1+] are names of variables to remove
+ * @param argv Command argv from user input.
+ *               - argv[0] should be "unset"
+ *               - argv[1+] are names of variables to remove
  * @param data Shell state, including environment and exit status.
  * @return Exit status of the command (0 on success, >0 on failure).
  */
-int	builtin_unset(char **tokens, t_shell *data)
+int	builtin_unset(char **argv, t_shell *data)
 {
 	int	i;
 
-	if (!tokens || !data)
+	if (!argv || !data)
 	{
 		data->status = INTERNAL_ERROR;
 		return (data->status);
 	}
 	i = 1;
-	while (tokens[i])
+	while (argv[i])
 	{
-		if (ft_strchr(tokens[i], '='))
+		if (ft_strchr(argv[i], '='))
 		{
 			i++;
 			continue ;
 		}
-		remove_env_node(&data->env_list, tokens[i]);
+		remove_env_node(&data->env_list, argv[i]);
 		i++;
 	}
 	data->status = EXIT_SUCCESS;

--- a/src/core/minishell_loop.c
+++ b/src/core/minishell_loop.c
@@ -114,7 +114,7 @@ static int	process_tokens(char *line, t_shell *data,
  * @return EXIT_SUCCESS on success, otherwise an error code indicating
  * the failure.
  */
-static int	process_ast(t_token *token_list, t_ast **ast)
+static int	process_ast(t_token *token_list, t_ast **ast, t_shell *data)
 {
 	int	status;
 
@@ -125,6 +125,7 @@ static int	process_ast(t_token *token_list, t_ast **ast)
 	status = validate_syntax_ast_list(*ast);
 	if (status != EXIT_SUCCESS)
 		return (status); // already returns MISUSAGE_ERROR for bad syntax
+	expand_ast_nodes(*ast, data);
 	status = assign_argv_and_filename(*ast);
 	if (status != EXIT_SUCCESS)
 		return (status); // could return EXIT_FAILURE or something custom
@@ -173,14 +174,11 @@ int	process_line(char *line, t_shell *data)
 	result = process_tokens(line, data, &tokens, &token_list);
 	if (result != EXIT_SUCCESS)
 		return(cleanup_process_line(tokens, NULL, token_list, line), result);
-	result = process_ast(token_list, &ast_list);
+	result = process_ast(token_list, &ast_list, data);
 	if (result != EXIT_SUCCESS)
 		return (cleanup_process_line(tokens, ast_list, token_list, line), result);
-	// TODO: quotes, redirs, pipes...
-	expand_ast_nodes(ast_list, data);
-	// DELETE THIS ONE ONCE REFACTOR WITH AST USE IS DONE
-	sync_tokens_with_ast(tokens, ast_list);
-	if (!execute_builtin(tokens, data))
+	//sync_tokens_with_ast(tokens, ast_list);
+	if (!execute_builtin(ast_list, data))
 		result = execute_external_command(tokens, data);
 	else
 		result = data->status;

--- a/src/expansion/expansion_integrate_ast.c
+++ b/src/expansion/expansion_integrate_ast.c
@@ -71,7 +71,7 @@ void	expand_ast_nodes(t_ast *ast_list, t_shell *data)
 	{
 		// Expand variables in commands and redirection filenames
 		if (current->value && (current->type == NODE_CMD
-			|| current->type == NODE_REDIR || current->type == NODE_NONE))
+			|| current->type == NODE_NONE))
 		{
 			expanded = expand_variables_in_string(current->value, data);
 			if (expanded)

--- a/src/parser/validate_syntax.c
+++ b/src/parser/validate_syntax.c
@@ -106,7 +106,7 @@ int	validate_syntax_ast_list(t_ast *list)
 		{
 			if (!curr->right)
 				return (syntax_error(NULL));
-			if (curr->right->type == NODE_PIPE && curr->right->type == NODE_REDIR)
+			if (curr->right->type == NODE_PIPE || curr->right->type == NODE_REDIR)
 				return (syntax_error(curr->right)); //checkes consecutive operators
 		}
 		curr = curr->right;


### PR DESCRIPTION
This PR refactors the builtin command handling in the shell:

Updated builtin table signatures: Builtins now receive the fully parsed, syntax-validated, and expanded t_ast list instead of raw token arrays.

Changed builtin function parameters: All builtin functions now use char **argv instead of char **tokens or single char *token.

Expansion moved earlier: Variable expansion now occurs before assigning argv and redirection filenames, ensuring builtins operate on fully expanded values.

Improved type safety and clarity: The AST now clearly owns the raw token strings, while argv and filename point to already-expanded strings.

Minor cleanups: Updated comments, removed redundant checks, and ensured consistent handling across builtins.