### PR TITLE
Feature/execution redirections and AST execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SRC =	src/builtins/cd.c \
 		src/execution/execute_pipeline.c \
 		src/execution/find_executable.c \
 		src/execution/pipeline_wait.c \
+		src/execution/redirections.c \
 		src/expansion/expansion.c \
 		src/expansion/expansion_extract.c \
 		src/expansion/expansion_replace.c \

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ SRC =	src/builtins/cd.c \
 		src/execution/execute_ast_tree.c \
 		src/execution/execute_builtins.c \
 		src/execution/execute_external_cmd.c \
+		src/execution/heredoc.c \
 		src/execution/execute_pipeline.c \
 		src/execution/find_executable.c \
 		src/execution/pipeline_wait.c \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SRC =	src/builtins/cd.c \
 		src/core/minishell_loop.c \
 		src/core/print_ascii_art.c \
 		src/env/env_import.c \
+		src/execution/ast_utils.c \
 		src/execution/build_env_array.c \
 		src/execution/execute_ast_tree.c \
 		src/execution/execute_builtins.c \

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ SRC =	src/builtins/cd.c \
 		src/execution/execute_pipeline.c \
 		src/execution/find_executable.c \
 		src/execution/pipeline_wait.c \
+		src/execution/fd_utils.c \
 		src/execution/redirections.c \
 		src/expansion/expansion.c \
 		src/expansion/expansion_extract.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -13,6 +13,7 @@
 # include <readline/readline.h>
 # include <readline/history.h>
 # include <sys/wait.h>
+# include <fcntl.h>
 
 /* =========================== */
 /*         CONSTANTS           */
@@ -58,6 +59,8 @@ typedef struct s_env
 }	t_env;
 
 /* shell state and configuration */
+typedef struct s_ast	t_ast;
+
 typedef struct s_shell
 {
 	t_list	*env_list;
@@ -65,6 +68,7 @@ typedef struct s_shell
 	bool	is_tty;
 	bool	is_child;
 	bool	should_exit;
+	t_ast	*curr_ast;
 }	t_shell;
 
 /* for builtin functions array, stores cmd and function's pointer*/
@@ -270,6 +274,13 @@ int			execute_external_command(char **tokens, t_shell *data);
 /* src/execution/execute_pipeline.c */
 int			execute_pipeline(t_ast *node, t_shell *data);
 
+/* src/execution/fd_utils.c */
+void		close_fds(int *fd);
+void		close_all_heredocs(t_ast *node);
+void		close_pipe_fds(int pipefd[2]);
+int			save_std_fds(int saved_fds[3]);
+void		restore_std_fds(int saved_fds[3]);
+
 /* src/execution/find_executable.c */
 char		*find_executable(char *cmd, t_shell *data);
 
@@ -278,7 +289,7 @@ int			preprocess_heredocs(t_ast *node, t_shell *data);
 
 /* src/execution/pipeline_wait.c */
 int			handle_pipeline_status(int status, t_shell *data);
-int			wait_pipeline(pid_t left_pid, pid_t right_pid, int pipefd[2], t_shell *data);
+int			wait_pipeline(pid_t left_pid, pid_t right_pid, t_shell *data);
 
 /* src/execution/redirections.c */
 int			apply_redirections(t_ast *node, t_shell *data);
@@ -326,7 +337,7 @@ t_ast		*create_cmd_node(char **argv);
 t_ast		*create_pipe_node(t_ast *left, t_ast *right);
 
 /* src/ast_free.c */
-void		free_strings_in_node(t_ast *node);
+void		cleanup_node(t_ast *node);
 void		free_ast(t_ast *node);
 
 /* src/ast_print.c */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -260,9 +260,6 @@ bool		execute_builtin(t_ast *node, t_shell *data);
 
 /* src/execution/execute_external_cmd.c */
 int			execute_external_command(char **tokens, t_shell *data);
-void		child_process(char *path, char **tokens, char **envp);
-int			handle_fork_error(char *path, char **envp);
-int			parent_process(int status);
 
 /* src/execution/execute_pipeline.c */
 int			execute_pipeline(t_ast *node, t_shell *data);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -268,6 +268,9 @@ int			execute_pipeline(t_ast *node, t_shell *data);
 /* src/execution/find_executable.c */
 char		*find_executable(char *cmd, t_shell *data);
 
+/* src/execution/heredoc.c */
+int			preprocess_heredocs(t_ast *node, t_shell *data);
+
 /* src/execution/pipeline_wait.c */
 int			handle_pipeline_status(int status, t_shell *data);
 int			wait_pipeline(pid_t left_pid, pid_t right_pid, int pipefd[2], t_shell *data);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -151,6 +151,7 @@ typedef struct s_ast
 	char			*value; // raw token string (cmd or word)
 	char			**argv; // only for NODE_CMD
 	char			*filename; // only for NODE_REDIR
+	int				heredoc_fd;
 	struct s_ast	*left; // pipe left
 	struct s_ast	*right; // pipe right
 	struct s_ast	*next; // used temporarily for flat list

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -275,6 +275,9 @@ int			preprocess_heredocs(t_ast *node, t_shell *data);
 int			handle_pipeline_status(int status, t_shell *data);
 int			wait_pipeline(pid_t left_pid, pid_t right_pid, int pipefd[2], t_shell *data);
 
+/* src/execution/redirections.c */
+int			apply_redirections(t_ast *node, t_shell *data);
+
 /* =========================== */
 /*         EXPANSION           */
 /* =========================== */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -249,6 +249,11 @@ t_list		*init_env_from_envp(char **envp);
 /*         EXECUTION           */
 /* =========================== */
 
+/* src/execution/ast_utils.c */
+bool		should_fork(t_ast *node, t_shell *data);
+bool		is_builtin(t_ast *node);
+bool		is_nonforking_builtin(t_ast *node);
+
 /* src/execution/build_env_array.c */
 char		**env_list_to_array(t_list *env_list);
 
@@ -257,7 +262,7 @@ int			execute_ast_tree(t_ast *node, t_shell *data);
 // int		execute_pipeline(t_ast *node, t_shell *data); // needs to be coded
 
 /* src/execution/execute_builtin.c */
-bool		execute_builtin(t_ast *node, t_shell *data);
+int			execute_builtin(t_ast *node, t_shell *data);
 
 /* src/execution/execute_external_cmd.c */
 int			execute_external_command(char **tokens, t_shell *data);

--- a/src/core/init_shell.c
+++ b/src/core/init_shell.c
@@ -54,5 +54,6 @@ int	init_shell(t_shell *data, char **envp)
 	data->is_tty = isatty(STDIN_FILENO);
 	data->is_child = false;
 	data->should_exit = false;
+	data->curr_ast = NULL;
 	return (0);
 }

--- a/src/core/minishell_loop.c
+++ b/src/core/minishell_loop.c
@@ -150,7 +150,9 @@ int	process_line(char *line, t_shell *data)
 	if (preprocess_heredocs(ast, data) != EXIT_SUCCESS)
 		return (cleanup_line(tokens, token_list, ast, line), EXIT_FAILURE);
 	//print_ast(ast, 0);
+	data->curr_ast = ast;
 	data->status = execute_ast_tree(ast, data);
+	data->curr_ast = NULL;
 	cleanup_line(tokens, token_list, ast, line);
 	return (data->status);
 }

--- a/src/core/minishell_loop.c
+++ b/src/core/minishell_loop.c
@@ -149,7 +149,7 @@ int	process_line(char *line, t_shell *data)
 		return (cleanup_line(tokens, token_list, NULL, line), EXIT_FAILURE);
 	if (preprocess_heredocs(ast, data) != EXIT_SUCCESS)
 		return (cleanup_line(tokens, token_list, ast, line), EXIT_FAILURE);
-	//print_ast(ast, 0);
+	print_ast(ast, 0);
 	data->curr_ast = ast;
 	data->status = execute_ast_tree(ast, data);
 	data->curr_ast = NULL;

--- a/src/core/minishell_loop.c
+++ b/src/core/minishell_loop.c
@@ -149,8 +149,8 @@ int	process_line(char *line, t_shell *data)
 		return (cleanup_line(tokens, token_list, NULL, line), EXIT_FAILURE);
 	if (preprocess_heredocs(ast, data) != EXIT_SUCCESS)
 		return (cleanup_line(tokens, token_list, ast, line), EXIT_FAILURE);
-	print_ast(ast, 0);
-	//data->status = execute_ast_tree(ast, data);
+	//print_ast(ast, 0);
+	data->status = execute_ast_tree(ast, data);
 	cleanup_line(tokens, token_list, ast, line);
 	return (data->status);
 }

--- a/src/core/minishell_loop.c
+++ b/src/core/minishell_loop.c
@@ -147,8 +147,10 @@ int	process_line(char *line, t_shell *data)
 	ast = build_ast_from_tokens(token_list);
 	if (!ast)
 		return (cleanup_line(tokens, token_list, NULL, line), EXIT_FAILURE);
-//	print_ast(ast, 0);
-	data->status = execute_ast_tree(ast, data);
+	if (preprocess_heredocs(ast, data) != EXIT_SUCCESS)
+		return (cleanup_line(tokens, token_list, ast, line), EXIT_FAILURE);
+	print_ast(ast, 0);
+	//data->status = execute_ast_tree(ast, data);
 	cleanup_line(tokens, token_list, ast, line);
 	return (data->status);
 }

--- a/src/core/minishell_loop.c
+++ b/src/core/minishell_loop.c
@@ -149,7 +149,7 @@ int	process_line(char *line, t_shell *data)
 		return (cleanup_line(tokens, token_list, NULL, line), EXIT_FAILURE);
 	if (preprocess_heredocs(ast, data) != EXIT_SUCCESS)
 		return (cleanup_line(tokens, token_list, ast, line), EXIT_FAILURE);
-	print_ast(ast, 0);
+	//print_ast(ast, 0);
 	data->curr_ast = ast;
 	data->status = execute_ast_tree(ast, data);
 	data->curr_ast = NULL;

--- a/src/execution/ast_utils.c
+++ b/src/execution/ast_utils.c
@@ -1,0 +1,76 @@
+#include "minishell.h"
+
+/**
+ * @brief Determine whether a command should be executed in a separate process.
+ *
+ * Non-forking builtins (like cd, export, unset, exit) are executed in the parent
+ * process to affect shell state. All other commands, including external commands
+ * and forkable builtins, should be executed in a child process.
+ *
+ * @param node AST node containing the command.
+ * @param data Pointer to the shell state (currently unused but may be needed later).
+ * @return true if the command should be executed in a child process; false otherwise.
+ */
+bool	should_fork(t_ast *node, t_shell *data)
+{
+	(void)data;
+	if (!node || node->type != NODE_CMD)
+		return (false);
+	if (is_builtin(node))
+	{
+		if (is_nonforking_builtin(node))
+			return (false);
+	}
+	return (true);
+}
+
+/**
+ * @brief Check if the AST node represents a builtin command.
+ *
+ * @param node AST node containing the command.
+ * @return true if the command is a builtin (pwd, export, exit, echo, env, unset, cd);
+ *         false otherwise.
+ */
+bool	is_builtin(t_ast *node)
+{
+	int					i;
+	static const char	*builtins[] = {
+		"pwd", "export", "exit", "echo", "env", "unset", "cd", NULL};
+
+	if (!node || !node->value)
+		return (false);
+	i = 0;
+	while (builtins[i] != NULL)
+	{
+		if (ft_strcmp(node->value, builtins[i]) == 0)
+			return (true);
+		i++;
+	}
+	return (false);
+}
+
+/**
+ * @brief Check if a builtin command should run without forking.
+ *
+ * Some builtins need to run in the parent process to modify shell state directly.
+ *
+ * @param node AST node containing the command.
+ * @return true if the builtin is non-forking (cd, export, unset, exit); false otherwise.
+ */
+bool	is_nonforking_builtin(t_ast *node)
+{
+	int					i;
+	static const char	*non_forking[] = {
+		"cd", "export", "unset", "exit", NULL};
+
+	if (!node || !node->value)
+		return (false);
+	i = 0;
+	while (non_forking[i] != NULL)
+	{
+		if (ft_strcmp(node->value, non_forking[i]) == 0)
+			return (true);
+		i++;
+	}
+	return (false);
+}

--- a/src/execution/ast_utils.c
+++ b/src/execution/ast_utils.c
@@ -13,8 +13,9 @@
  */
 bool	should_fork(t_ast *node, t_shell *data)
 {
-	(void)data;
 	if (!node || node->type != NODE_CMD)
+		return (false);
+	if (data->is_child)
 		return (false);
 	if (is_builtin(node))
 	{

--- a/src/execution/execute_ast_tree.c
+++ b/src/execution/execute_ast_tree.c
@@ -1,42 +1,92 @@
 #include "minishell.h"
 
 /**
- * @brief Execute an AST node (command or pipeline).
+ * @brief Execute a single command (builtin or external) without forking.
  *
- * Recursively executes the abstract syntax tree built from the parsed
- * command line. Handles both simple commands and pipelines (TODO).
- * For simple commands, checks if it's a builtin first, otherwise
- * executes as an external command.
+ * If the AST node represents a builtin, it executes it via `execute_builtin`.
+ * Otherwise, it executes an external command using `execute_external_command`.
  *
- * @param node AST node to execute (NODE_CMD or NODE_PIPE)
- * @param data Shell data structure
- * @return Exit status of the executed command
+ * @param node AST node representing the command.
+ * @param data Pointer to the shell state structure.
+ * @return int The exit status of the command. For builtins, it is `data->status`;
+ *             for external commands, `data->status` is updated by `execute_external_command`.
+ */
+static int	execute_command(t_ast *node, t_shell *data)
+{
+	if (!node || node->type != NODE_CMD)
+		return (EXIT_SUCCESS);
+	if (is_builtin(node))
+		return (execute_builtin(node, data));
+	else
+		execute_external_command(node->argv, data);
+	return (data->status);
+}
+
+/**
+ * @brief Execute a command in a child process, applying redirections if needed.
  *
- * @note Redirections (node->right) are not yet implemented (TODO).
- * @note Pipeline execution is not yet implemented (TODO).
+ * Forks a new child process, applies any redirections on the right side of the node,
+ * then executes the command (builtin or external) inside the child. The parent waits
+ * for the child to finish and updates `data->status` with the child’s exit status.
+ *
+ * @param node AST node representing the command to execute in the child.
+ * @param data Pointer to the shell state structure.
+ * @return int The exit status of the child process, stored in `data->status`.
+ */
+static int	execute_in_child_process(t_ast *node, t_shell *data)
+{
+	pid_t	pid;
+	int		status;
+
+	pid = fork();
+	if (pid == -1)
+	{
+		perror("fork");
+		return (EXIT_FAILURE);
+	}
+	if (pid == 0) // child
+	{
+		data->is_child = true;
+		if (apply_redirections(node->right, data) != EXIT_SUCCESS)
+			exit (data->status);
+		exit(execute_command(node, data));
+	}
+	waitpid(pid, &status, 0);
+	if (WIFEXITED(status))
+		data->status = WEXITSTATUS(status);
+	else
+		data->status = EXIT_FAILURE;
+	return (data->status);
+}
+
+/**
+ * @brief Recursively execute an AST tree representing commands and pipelines.
+ *
+ * Handles pipelines, builtins (forking and non-forking), and external commands.
+ * Redirections are applied before execution. The function decides when to fork
+ * for commands that should run in a separate process.
+ *
+ * @param node Root AST node of the tree/subtree to execute.
+ * @param data Pointer to the shell state structure.
+ * @return int The exit status of the last executed command in the tree,
+ *             stored in `data->status`.
  */
 int	execute_ast_tree(t_ast *node, t_shell *data)
 {
 	if (!node)
 		return (EXIT_SUCCESS);
 	if (node->type == NODE_PIPE)
-		return (execute_pipeline(node, data));
-	else if (node->type == NODE_CMD)
+		return (execute_pipeline(node, data)); //forks
+	// Non-forking builtins that dont modify parent state
+	if (node->type == NODE_CMD && is_nonforking_builtin(node))
 	{
-		// TODO: Handle redirections in node->right first
-		// Check if it's a builtin command
-		if (execute_builtin(node, data))
-		{
-		// Builtin executed successfully
-		// In child process (pipeline): must exit, not return
-		// Note: 'exit' builtin handles is_child internally and exits before returning here
-		if (data->is_child)
-			exit(data->status);
-		// In parent: return to display next prompt
+		data->status = execute_builtin(node, data); //runs in parent
 		return (data->status);
-		}
-		// Not a builtin: execute external command (forks internally)
-		return (execute_external_command(node->argv, data));
 	}
-	return (EXIT_SUCCESS);
+	// forking commands (external or forkable builtins)
+	if (should_fork(node, data))
+		return (execute_in_child_process(node, data));
+	// non forking builtin - execute directly
+	data->status = execute_command(node, data);
+	return (data->status);
 }

--- a/src/execution/execute_builtins.c
+++ b/src/execution/execute_builtins.c
@@ -28,6 +28,8 @@ int	execute_builtin(t_ast *node, t_shell *data)
 
 	if (!node || !node->value)
 		return (EXIT_FAILURE);
+	if (data->curr_ast && data->is_child)
+		close_all_heredocs(data->curr_ast);
 	i = 0;
 	while (builtins[i].cmd != NULL)
 	{

--- a/src/execution/execute_builtins.c
+++ b/src/execution/execute_builtins.c
@@ -1,17 +1,22 @@
 #include "minishell.h"
 
 /**
- * @brief Check and execute a builtin command.
+ * @brief Execute a shell builtin command if it matches a known builtin.
  *
- * Compares the first token against the list of supported builtins,
- * including `exit`. If a match is found, executes the corresponding
- * function and updates `data->status`. Does not execute external commands.
+ * This function checks the command in the given AST node against the list
+ * of supported builtin commands (`pwd`, `export`, `exit`, `echo`, `env`,
+ * `unset`, `cd`). If a match is found, the corresponding function is executed,
+ * and the shell state (`data->status`) is updated accordingly.
  *
- * @param node AST node representing the command.
- * @param data Shell state, including environment, exit status, and exit flag.
- * @return true if the command is a builtin and was executed; false otherwise.
+ * This function does **not** handle external commands; it only executes builtins.
+ *
+ * @param node Pointer to the AST node representing the command.
+ * @param data Pointer to the shell state structure, which includes environment,
+ *             exit status, and other runtime flags.
+ * @return int The updated exit status after executing the builtin, or
+ *             EXIT_FAILURE if the command is not a builtin or the node is invalid.
  */
-bool	execute_builtin(t_ast *node, t_shell *data)
+int	execute_builtin(t_ast *node, t_shell *data)
 {
 	int						i;
 	static const t_builtin	builtins[] = {
@@ -22,16 +27,16 @@ bool	execute_builtin(t_ast *node, t_shell *data)
 	{NULL, NULL}};
 
 	if (!node || !node->value)
-		return (false);
+		return (EXIT_FAILURE);
 	i = 0;
 	while (builtins[i].cmd != NULL)
 	{
 		if (ft_strcmp(node->value, builtins[i].cmd) == 0)
 		{
 			builtins[i].f(node->argv, data);
-			return (true);
+			return (data->status);
 		}
 		i++;
 	}
-	return (false);
+	return (EXIT_FAILURE);
 }

--- a/src/execution/execute_external_cmd.c
+++ b/src/execution/execute_external_cmd.c
@@ -56,6 +56,9 @@ int	execute_external_command(char **argv, t_shell *data)
 	init_status = init_execution(argv, data, &path, &envp);
 	if (init_status != 0)
 		exit (init_status);
+	// close unused heredocs before execve
+	if (data->curr_ast)
+		close_all_heredocs(data->curr_ast);
 	// Try to execute the external command
 	execve(path, argv, envp);
 	// If execve returns, it failed, so clean up before exiting

--- a/src/execution/execute_external_cmd.c
+++ b/src/execution/execute_external_cmd.c
@@ -62,6 +62,5 @@ int	execute_external_command(char **tokens, t_shell *data)
 	perror("execve");
 	free(path);
 	free_strings_array(envp);
-	// Extract and return exit code from child
 	exit(CMD_NOT_EXECUTABLE);
 }

--- a/src/execution/execute_external_cmd.c
+++ b/src/execution/execute_external_cmd.c
@@ -33,118 +33,35 @@ static int	init_execution(char **tokens, t_shell *data, char **path,
 }
 
 /**
- * @brief Execute command in child process.
+ * @brief Execute an external command in the current (child) process.
  *
- * Marks the shell as running in a child process, then replaces
- * the current process image with the specified command using execve().
- * If execve() fails (ex: permission denied), prints an error and
- * exits with code 126.
+ * This function prepares the executable path and environment array, then
+ * replaces the current process image with the external program using `execve()`.
+ * It is intended to be called only in a forked child process.
  *
- * @param path Full path to the executable
- * @param tokens Command arguments (argv for execve)
- * @param envp Environment variables array
+ * @param tokens Argument vector for the command (NULL-terminated).
+ * @param data   Pointer to the main shell structure containing environment data.
  *
- * @note This function does not return on success (process is replaced).
- *		 Only returns via exit() if execve() fails.
- */
-void	child_process(char *path, char **tokens, char **envp)
-{
-	execve(path, tokens, envp);
-	// execve failed - cleanup before exit
-	free(path);
-	free_strings_array(envp);
-	perror("execve");
-	exit(CMD_NOT_EXECUTABLE);
-}
-
-/**
- * @brief Handle fork() failure by cleaning up resources.
- *
- * @param path Allocated path string to free
- * @param envp Allocated environment array to free
- * @return EXIT_FAILURE (1)
- */
-int	handle_fork_error(char *path, char **envp)
-{
-	perror("fork");
-	free(path);
-	free_strings_array(envp);
-	return (EXIT_FAILURE);
-}
-
-/**
- * @brief Extract and return the exit status from a child process.
- *
- * Analyzes the status value returned by wait() to determine how
- * the child process terminated and extracts the appropriate exit code.
- *
- * @param status Status value from wait() or waitpid()
- * @return Exit code of the child process if it terminated normally,
- *	 EXIT_FAILURE (1) if terminated abnormally
- */
-int	parent_process(int status)
-{
-	if (WIFEXITED(status))
-		return (WEXITSTATUS(status));
-	return (EXIT_FAILURE);
-}
-
-/**
- * @brief Execute an external (non-builtin) command.
- *
- * Resolves the command path using the environment, then executes it
- * either by forking a new process or directly within an existing child
- * (for pipeline execution).
- *
- * - If already inside a child process (from a pipeline), the function
- *   performs setup, calls execve(), and exits with the correct status
- *   if execution fails. No additional fork is performed in this case.
- * - If in the main shell process, it forks a new child, executes the
- *   command there, and waits for completion to retrieve the exit code.
- *
- * All allocated resources (path and environment array) are properly freed
- * before returning or exiting. The final exit code matches bash behavior:
- *  - 127 for command not found
- *  - 126 for permission denied
- *  - exit status of the executed program otherwise
- *
- * @param tokens Command arguments, where tokens[0] is the command name.
- * @param data   Shell data structure containing context and flags.
- * @return Exit status of the executed command (in parent context).
- *         In child context, this function does not return.
+ * @note This function never returns. If `execve()` fails, it cleans up and exits
+ *       with `CMD_NOT_EXECUTABLE`. The parent process should handle the exit code
+ *       via `waitpid()`.
  */
 int	execute_external_command(char **tokens, t_shell *data)
 {
-	pid_t	pid;
 	char	*path;
 	char	**envp;
 	int		init_status;
-	int		child_status;
 
-	// check if in child first (from pipeline): execute directly without forking again
-	if (data->is_child)
-	{
-		init_status = init_execution(tokens, data, &path, &envp);
-		if (init_status != 0)
-			exit(init_status);
-		child_process(path, tokens, envp);  // Never returns (execve or exit)
-	}
 	// Find executable path and prepare environment array for execve
 	init_status = init_execution(tokens, data, &path, &envp);
 	if (init_status != 0)
-		return (init_status);
-	// Normal case: fork a new child process
-	pid = fork();
-	if (pid == -1)
-		return (handle_fork_error(path, envp));
-	// Child: replace process with command
-	if (pid == 0)
-		child_process(path, tokens, envp);  // Never returns
-	// Parent: wait for child to complete
-	waitpid(pid, &child_status, 0);
-	// Cleanup allocated resources
+		exit (init_status);
+	// Try to execute the external command
+	execve(path, tokens, envp);
+	// If execve returns, it failed, so clean up before exiting
+	perror("execve");
 	free(path);
 	free_strings_array(envp);
 	// Extract and return exit code from child
-	return (parent_process(child_status));
+	exit(CMD_NOT_EXECUTABLE);
 }

--- a/src/execution/execute_external_cmd.c
+++ b/src/execution/execute_external_cmd.c
@@ -7,20 +7,20 @@
  * the environment list into an array suitable for execve(). If any step
  * fails, cleans up allocated resources and returns an error code.
  *
- * @param tokens Command arguments (tokens[0] is the command name)
+ * @param argv Command arguments (argv[0] is the command name)
  * @param data Shell data structure containing environment
  * @param path Output parameter for the executable path
  * @param envp Output parameter for the environment array
  * @return 0 on success, CMD_NOT_FOUND (127) if command not found,
  *	 EXIT_FAILURE (1) if env conversion fails
  */
-static int	init_execution(char **tokens, t_shell *data, char **path,
+static int	init_execution(char **argv, t_shell *data, char **path,
 	char ***envp)
 {
-	*path = find_executable(tokens[0], data);
+	*path = find_executable(argv[0], data);
 	if (!*path)
 	{
-		print_error(tokens[0], ERR_CMD_NOT_FOUND, NULL, NULL);
+		print_error(argv[0], ERR_CMD_NOT_FOUND, NULL, NULL);
 		return (CMD_NOT_FOUND);
 	}
 	*envp = env_list_to_array(data->env_list);
@@ -39,25 +39,25 @@ static int	init_execution(char **tokens, t_shell *data, char **path,
  * replaces the current process image with the external program using `execve()`.
  * It is intended to be called only in a forked child process.
  *
- * @param tokens Argument vector for the command (NULL-terminated).
+ * @param argv Argument vector for the command (NULL-terminated).
  * @param data   Pointer to the main shell structure containing environment data.
  *
  * @note This function never returns. If `execve()` fails, it cleans up and exits
  *       with `CMD_NOT_EXECUTABLE`. The parent process should handle the exit code
  *       via `waitpid()`.
  */
-int	execute_external_command(char **tokens, t_shell *data)
+int	execute_external_command(char **argv, t_shell *data)
 {
 	char	*path;
 	char	**envp;
 	int		init_status;
 
 	// Find executable path and prepare environment array for execve
-	init_status = init_execution(tokens, data, &path, &envp);
+	init_status = init_execution(argv, data, &path, &envp);
 	if (init_status != 0)
 		exit (init_status);
 	// Try to execute the external command
-	execve(path, tokens, envp);
+	execve(path, argv, envp);
 	// If execve returns, it failed, so clean up before exiting
 	perror("execve");
 	free(path);

--- a/src/execution/execute_pipeline.c
+++ b/src/execution/execute_pipeline.c
@@ -165,17 +165,18 @@ int	execute_pipeline(t_ast *node, t_shell *data)
 	left_pid = fork_left_child(node, data, pipefd);
 	if (left_pid == -1)
 	{
-		close(pipefd[0]);
-		close(pipefd[1]);
+		close_pipe_fds(pipefd);
 		return (EXIT_FAILURE);
 	}
 	right_pid = fork_right_child(node, data, pipefd);
 	if (right_pid == -1)
 	{
-		close(pipefd[0]);
-		close(pipefd[1]);
+		close_pipe_fds(pipefd);
 		waitpid(left_pid, NULL, 0);
 		return (EXIT_FAILURE);
 	}
-	return (wait_pipeline(left_pid, right_pid, pipefd, data));
+	close_pipe_fds(pipefd);
+	//if (data->curr_ast)
+	//	close_all_heredocs(data->curr_ast);
+	return (wait_pipeline(left_pid, right_pid, data));
 }

--- a/src/execution/execute_pipeline.c
+++ b/src/execution/execute_pipeline.c
@@ -33,6 +33,8 @@ static void	execute_left_child(t_ast *node, t_shell *data, int pipefd[2])
 		exit(EXIT_FAILURE);
 	}
 	close(pipefd[1]);
+	if (data->curr_ast)
+		close_all_heredocs(data->curr_ast);
 	execute_ast_tree(node->left, data);
 	exit(data->status);
 }
@@ -93,6 +95,8 @@ static void	execute_right_child(t_ast *node, t_shell *data, int pipefd[2])
 		exit(EXIT_FAILURE);
 	}
 	close(pipefd[0]);
+	if (data->curr_ast)
+		close_all_heredocs(data->curr_ast);
 	execute_ast_tree(node->right, data);
 	exit(data->status);
 }

--- a/src/execution/execute_pipeline.c
+++ b/src/execution/execute_pipeline.c
@@ -40,25 +40,17 @@ static void	execute_left_child(t_ast *node, t_shell *data, int pipefd[2])
 /**
  * @brief Fork and execute the left side of a pipeline.
  *
- * This function creates a new child process to handle the left command
- * in a pipeline (e.g., `cmd1` in `cmd1 | cmd2`). The child redirects
- * its standard output to the pipe’s write end and executes the left
- * subtree of the AST.
+ * Creates a child process for the left command of a pipeline (e.g., `cmd1` in `cmd1 | cmd2`).
+ * The child process will redirect its standard output to the pipe’s write end
+ * and execute the left subtree of the AST via `execute_left_child()`.
  *
- * @param node Pointer to the current AST node representing the pipeline.
- * @param data Pointer to the shell state structure.
- * @param pipefd The pipe file descriptors; pipefd[0] is the read end,
- *               and pipefd[1] is the write end.
- *
- * @return The PID of the forked child process on success, or -1 on failure.
+ * @param node AST node representing the pipeline.
+ * @param data Shell state structure.
+ * @param pipefd Array of two integers: pipefd[0] is read end, pipefd[1] is write end.
+ * @return PID of the forked left child on success, -1 on failure.
  *
  * @details
- * Steps performed:
- * 1. Call `fork()` to create a new process.
- * 2. In the child:
- *      - Execute the left side using `execute_left_child()`.
- * 3. In the parent:
- *      - Return the PID of the left child for later `waitpid()` calls.
+ * The parent process receives the PID for later use in `waitpid()`.
  */
 static	pid_t	fork_left_child(t_ast *node, t_shell *data, int pipefd[2])
 {
@@ -78,24 +70,17 @@ static	pid_t	fork_left_child(t_ast *node, t_shell *data, int pipefd[2])
 /**
  * @brief Execute the right side of a pipeline in a child process.
  *
- * This function runs the right command of a pipe (e.g., in `cmd1 | cmd2`),
- * redirecting its standard input to the read end of the pipe so that it
- * receives the output from the left command. It closes unused file
- * descriptors and ensures proper exit with the child’s execution status.
+ * Redirects standard input to the pipe’s read end so the child receives
+ * the output from the left command. Closes unused file descriptors and
+ * executes the right subtree of the AST.
  *
- * @param node Pointer to the current AST node representing the pipeline.
- * @param data Pointer to the shell state structure.
- * @param pipefd The pipe file descriptors; pipefd[0] is the read end,
- *               and pipefd[1] is the write end.
+ * @param node AST node representing the pipeline.
+ * @param data Shell state structure.
+ * @param pipefd Array of two integers: pipefd[0] is read end, pipefd[1] is write end.
  *
  * @details
- * Steps performed:
- * 1. Mark the shell as a child process (`data->is_child = true`).
- * 2. Close the unused write end of the pipe (`pipefd[1]`).
- * 3. Redirect `STDIN_FILENO` to the pipe’s read end via `dup2()`.
- * 4. Close the read end after duplication to avoid file descriptor leaks.
- * 5. Recursively execute the right subtree of the AST.
- * 6. Exit the process using the current shell status.
+ * After execution, the child exits with the current shell status.
+ * The read end is closed after duplication to prevent descriptor leaks.
  */
 static void	execute_right_child(t_ast *node, t_shell *data, int pipefd[2])
 {
@@ -151,31 +136,20 @@ static pid_t	fork_right_child(t_ast *node, t_shell *data, int pipefd[2])
 }
 
 /**
- * @brief Execute a pipeline between two commands.
+ * @brief Execute a pipeline node in the AST.
  *
- * This function handles the execution of a pipeline node in the AST
- * (e.g., `cmd1 | cmd2`). It creates a pipe, forks two child processes
- * for the left and right commands, and connects their standard output
- * and input through the pipe.
+ * Handles a pipeline between two commands (e.g., `cmd1 | cmd2`):
+ * creates a pipe, forks two children, connects their input/output
+ * through the pipe, and waits for both processes to finish.
  *
- * @param node Pointer to the current AST node representing the pipeline.
- * @param data Pointer to the shell state structure.
- *
- * @return The exit status of the rightmost command in the pipeline.
+ * @param node AST node representing the pipeline.
+ * @param data Shell state structure.
+ * @return Exit status of the rightmost command in the pipeline,
+ *         or EXIT_FAILURE on error.
  *
  * @details
- * Steps performed:
- * 1. Create a pipe with `pipe()`.
- * 2. Fork the left child process via `fork_left_child()` to handle
- *    the left side of the pipeline (writes to the pipe).
- * 3. Fork the right child process via `fork_right_child()` to handle
- *    the right side of the pipeline (reads from the pipe).
- * 4. Close the pipe ends in the parent process.
- * 5. Wait for both child processes to finish using `wait_pipeline()`.
- *
- * On failure to create the pipe or fork any child, the function ensures
- * all open file descriptors are closed and previously forked children
- * are waited for before returning an error status.
+ * On any failure (pipe creation or fork), ensures open file descriptors are
+ * closed and previously forked children are waited for before returning.
  */
 int	execute_pipeline(t_ast *node, t_shell *data)
 {

--- a/src/execution/execute_pipeline.c
+++ b/src/execution/execute_pipeline.c
@@ -33,6 +33,11 @@ static void	execute_left_child(t_ast *node, t_shell *data, int pipefd[2])
 		exit(EXIT_FAILURE);
 	}
 	close(pipefd[1]);
+	if (node->left && node->left->right)
+	{
+		if (apply_redirections(node->left->right, data) != EXIT_SUCCESS)
+			exit(data->status);
+	}
 	if (data->curr_ast)
 		close_all_heredocs(data->curr_ast);
 	execute_ast_tree(node->left, data);
@@ -95,6 +100,11 @@ static void	execute_right_child(t_ast *node, t_shell *data, int pipefd[2])
 		exit(EXIT_FAILURE);
 	}
 	close(pipefd[0]);
+	if (node->right && node->right->right)
+	{
+		if (apply_redirections(node->right->right, data) != EXIT_SUCCESS)
+			exit(data->status);
+	}
 	if (data->curr_ast)
 		close_all_heredocs(data->curr_ast);
 	execute_ast_tree(node->right, data);

--- a/src/execution/fd_utils.c
+++ b/src/execution/fd_utils.c
@@ -1,0 +1,128 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   fd_utils.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: diade-so <diade-so@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/10/14 11:58:59 by diade-so          #+#    #+#             */
+/*   Updated: 2025/10/14 16:14:06 by diade-so         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	close_fds(int *fd)
+{
+	if (fd && *fd >= 0)
+	{
+		close(*fd);
+		*fd = -1;
+	}
+}
+
+// recursion to support nested shells
+void	close_all_heredocs(t_ast *node)
+{
+	if (!node)
+		return ;
+	if (node->op_type == OP_HEREDOC && node->heredoc_fd >= 0)
+		close_fds(&node->heredoc_fd);
+	close_all_heredocs(node->left);
+	close_all_heredocs(node->right);
+}
+
+void	close_pipe_fds(int pipefd[2])
+{
+	close_fds(&pipefd[0]);
+	close_fds(&pipefd[1]);
+}
+
+/**
+ * @brief Save the standard file descriptors (stdin, stdout, stderr)
+ *
+ * Duplicates the three standard FDs so they can be restored later.
+ * Initializes all elements to -1 to safely track partial failures.
+ *
+ * @param saved_fds Array of 3 ints to store the duplicated FDs.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE if any dup() fails.
+ */
+int	save_std_fds(int saved_fds[3])
+{
+	memset(saved_fds, -1, sizeof(int) * 3);
+	if (saved_fds[0] == -1)
+	{
+		perror("dup");
+		return (EXIT_FAILURE);
+	}
+	saved_fds[1] = dup(STDOUT_FILENO);
+	if (saved_fds[1] == -1)
+	{
+		perror("dup");
+		close(saved_fds[0]);
+		saved_fds[0] = -1;
+		return (EXIT_FAILURE);
+	}
+	saved_fds[2] = dup(STDERR_FILENO);
+	if (saved_fds[2] == -1)
+	{
+		perror("dup");
+		close(saved_fds[0]);
+		close(saved_fds[1]);
+		saved_fds[0] = -1;
+		saved_fds[1] = -1;
+		return (EXIT_FAILURE);
+	}
+	return (EXIT_SUCCESS);
+}
+
+/**
+ * @brief Restore the standard file descriptors (stdin, stdout, stderr) from saved copies.
+ *
+ * This function restores the three standard file descriptors using previously saved
+ * duplicates in the `saved_fds` array. It safely handles cases where some FDs were
+ * never saved (i.e., remain negative), preventing spurious errors.
+ *
+ * After restoring each FD, the corresponding entry in `saved_fds` is set to -1
+ * to prevent accidental reuse.
+ *
+ * @param saved_fds An array of three integers containing saved duplicates of
+ *                  STDIN_FILENO, STDOUT_FILENO, and STDERR_FILENO, in that order.
+ *                  Values < 0 are ignored.
+ *
+ * @details
+ * - Attempts to restore only valid (>= 0) saved FDs.
+ * - If `dup2()` fails for any FD, prints an informative error via `perror()`,
+ *   but continues restoring the remaining FDs.
+ * - Closes each saved FD after restoration to avoid leaks.
+ *
+ * @note This function is useful for builtins or commands with temporary
+ *       redirections where the original standard streams must be restored
+ *       after execution.
+ */
+void	restore_std_fds(int saved_fds[3])
+{
+	//check first if saved FD is valid before attempting dup2 or close
+	if (saved_fds[0] >= 0)
+	{
+		if (dup2(saved_fds[0], STDIN_FILENO) == -1)
+			perror("restore stdin");
+		close(saved_fds[0]);
+		// after restoring set saved FD to -1 to prevent accidental double use
+		saved_fds[0] = -1;
+	}
+	if (saved_fds[1] >= 0)
+	{
+		if (dup2(saved_fds[1], STDOUT_FILENO) == -1)
+			perror("restore stdout");
+		close(saved_fds[1]);
+		saved_fds[1] = -1;
+	}
+	if (saved_fds[2] >= 0)
+	{
+		if (dup2(saved_fds[2], STDERR_FILENO) == -1)
+			perror("restore stderr");
+		close(saved_fds[2]);
+		saved_fds[2] = -1;
+	}
+}

--- a/src/execution/fd_utils.c
+++ b/src/execution/fd_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   fd_utils.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: diade-so <diade-so@student.42.fr>          +#+  +:+       +#+        */
+/*   By: pafroidu <pafroidu@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/14 11:58:59 by diade-so          #+#    #+#             */
-/*   Updated: 2025/10/14 16:14:06 by diade-so         ###   ########.fr       */
+/*   Updated: 2025/10/14 19:32:50 by pafroidu         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,11 +50,9 @@ void	close_pipe_fds(int pipefd[2])
 int	save_std_fds(int saved_fds[3])
 {
 	memset(saved_fds, -1, sizeof(int) * 3);
+	saved_fds[0] = dup(STDIN_FILENO);
 	if (saved_fds[0] == -1)
-	{
-		perror("dup");
-		return (EXIT_FAILURE);
-	}
+		return (perror("dup"), EXIT_FAILURE);
 	saved_fds[1] = dup(STDOUT_FILENO);
 	if (saved_fds[1] == -1)
 	{

--- a/src/execution/fd_utils.c
+++ b/src/execution/fd_utils.c
@@ -6,7 +6,7 @@
 /*   By: pafroidu <pafroidu@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/14 11:58:59 by diade-so          #+#    #+#             */
-/*   Updated: 2025/10/14 19:32:50 by pafroidu         ###   ########.fr       */
+/*   Updated: 2025/10/14 23:06:59 by diade-so         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ void	close_all_heredocs(t_ast *node)
 		close_fds(&node->heredoc_fd);
 	close_all_heredocs(node->left);
 	close_all_heredocs(node->right);
+	close_all_heredocs(node->next);
 }
 
 void	close_pipe_fds(int pipefd[2])

--- a/src/execution/heredoc.c
+++ b/src/execution/heredoc.c
@@ -83,7 +83,8 @@ int	preprocess_heredocs(t_ast *node, t_shell *data)
 		if (fd == -1)
 		{
 			//error reading heredoc - set status and return failure
-			data->status = EXIT_FAILURE; //may be propogated..
+			close_all_heredocs(node);
+			data->status = EXIT_FAILURE;
 			return (EXIT_FAILURE);
 		}
 		node->heredoc_fd = fd;

--- a/src/execution/heredoc.c
+++ b/src/execution/heredoc.c
@@ -92,5 +92,8 @@ int	preprocess_heredocs(t_ast *node, t_shell *data)
 	if (node->right)
 		if (preprocess_heredocs(node->right, data) != EXIT_SUCCESS)
 			return (EXIT_FAILURE);
+	if (node->next)
+		if (preprocess_heredocs(node->next, data) != EXIT_SUCCESS)
+			return (EXIT_FAILURE);
 	return (EXIT_SUCCESS);
 }

--- a/src/execution/heredoc.c
+++ b/src/execution/heredoc.c
@@ -1,0 +1,95 @@
+#include "minishell.h"
+
+/**
+ * @brief Creates a pipe and fills it with the contents of a heredoc.
+ *
+ * This function reads lines from the terminal until the specified
+ * limiter is reached. Each line is written to the write end of a
+ * newly created pipe. The write end is closed after all lines
+ * are written, leaving the read end open for later use in input
+ * redirection.
+ *
+ * @param limiter The string that ends the heredoc input.
+ * @return The file descriptor of the read end of the pipe on success,
+ *         or -1 if pipe creation fails.
+ *
+ * @details
+ * - Uses `readline()` to read input from the user.
+ * - Writes each line followed by a newline to the pipe.
+ * - Frees each line after writing.
+ * - Closes the write end of the pipe to signal EOF to readers.
+ */
+static int	create_heredoc_fd(const char *limiter)
+{
+	int		pipefd[2];
+	char	*line;
+
+	if (pipe(pipefd) == -1)
+	{
+		perror("pipe");
+		return (-1);
+	}
+	while (1)
+	{
+		line = readline("> ");
+		if (!line) //EOF (ctrl+D)
+			break ;
+		if (ft_strcmp(line, limiter) == 0)
+		{
+			free(line);
+			break ;
+		}
+		ft_putendl_fd(line, pipefd[1]); //writes line to pipe
+		free(line);
+	}
+	close(pipefd[1]); // close write end, keep read end open
+	return (pipefd[0]);
+}
+
+/**
+ * @brief Preprocesses all heredoc redirections in an AST.
+ *
+ * Recursively traverses the abstract syntax tree (AST) and, for
+ * each heredoc redirection node, creates a pipe containing the
+ * heredoc input. The read file descriptor is stored in the node’s
+ * `heredoc_fd` member for later use during execution.
+ *
+ * @param node Pointer to the current AST node.
+ * @param data Pointer to the shell state structure.
+ * @return EXIT_SUCCESS if all heredocs are processed successfully,
+ *         EXIT_FAILURE if any heredoc fails.
+ *
+ * @details
+ * - Traverses the left subtree first, then the current node, then
+ *   the right subtree (in-order traversal).
+ * - For each `NODE_REDIR` node with `op_type == OP_HEREDOC`,
+ *   calls `create_heredoc_fd()` to generate the pipe.
+ * - On failure, sets `data->status` to `EXIT_FAILURE` and
+ *   propagates the error.
+ */
+int	preprocess_heredocs(t_ast *node, t_shell *data)
+{
+	int	fd;
+
+	if (!node)
+		return (EXIT_SUCCESS);
+	if (node->left)
+		if (preprocess_heredocs(node->left, data) != EXIT_SUCCESS)
+			return (EXIT_FAILURE);
+	// handle heredoc for this node
+	if (node->type == NODE_REDIR && node->op_type == OP_HEREDOC)
+	{
+		fd = create_heredoc_fd(node->filename);
+		if (fd == -1)
+		{
+			//error reading heredoc - set status and return failure
+			data->status = EXIT_FAILURE; //may be propogated..
+			return (EXIT_FAILURE);
+		}
+		node->heredoc_fd = fd;
+	}
+	if (node->right)
+		if (preprocess_heredocs(node->right, data) != EXIT_SUCCESS)
+			return (EXIT_FAILURE);
+	return (EXIT_SUCCESS);
+}

--- a/src/execution/pipeline_wait.c
+++ b/src/execution/pipeline_wait.c
@@ -47,15 +47,14 @@ int	handle_pipeline_status(int status, t_shell *data)
  * The left child’s exit status is ignored, as shell semantics define
  * the pipeline’s return status to be that of the last command.
  */
-int	wait_pipeline(pid_t left_pid, pid_t right_pid,
-	int pipefd[2], t_shell *data)
+int	wait_pipeline(pid_t left_pid, pid_t right_pid, t_shell *data)
 {
 	int	status_left;
 	int	status_right;
 
-	close(pipefd[0]);
-	close(pipefd[1]);
 	waitpid(left_pid, &status_left, 0);
 	waitpid(right_pid, &status_right, 0);
+	if (data->curr_ast)
+		close_all_heredocs(data->curr_ast);
 	return (handle_pipeline_status(status_right, data));
 }

--- a/src/execution/redirections.c
+++ b/src/execution/redirections.c
@@ -42,7 +42,6 @@ static int	perform_dup(int fd, int target_fd, t_shell *data)
 			exit(data->status);
 		return (data->status);
 	}
-	close(fd);
 	return (EXIT_SUCCESS);
 }
 
@@ -106,6 +105,12 @@ static int	apply_single_redirection(t_ast *node, t_shell *data)
 		return (data->status);
 	}
 	result = dup_redirection(node, data, fd);
+	// mark heredoc fd as closed
+	if (node->op_type == OP_HEREDOC && result == EXIT_SUCCESS)
+		node->heredoc_fd = -1;
+	// always close origianl FD after successful dup2
+//	if (result == EXIT_SUCCESS)
+	close_fds(&fd);
 	return (result);
 }
 

--- a/src/execution/redirections.c
+++ b/src/execution/redirections.c
@@ -31,7 +31,7 @@ static int	get_target_fd(t_ast *node)
  * @param data Pointer to the main shell data structure.
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
  */
-static int	perform_dup(int, fd, int target_fd, t_ast *node, t_shell *data)
+static int	perform_dup(int fd, int target_fd, t_shell *data)
 {
 	if (dup2(fd, target_fd) == -1) //stdin now reads from fd
 	{
@@ -64,7 +64,7 @@ static int	dup_redirection(t_ast *node, t_shell *data, int fd)
 	int	result;
 
 	target_fd = get_target_fd(node);
-	result = perform_dup(fd, target_fd, node, data);
+	result = perform_dup(fd, target_fd, data);
 	return (result);
 }
 

--- a/src/execution/redirections.c
+++ b/src/execution/redirections.c
@@ -136,7 +136,7 @@ int	apply_redirections(t_ast *node, t_shell *data)
 		ret = apply_single_redirection(node, data);
 		if (ret != EXIT_SUCCESS)
 			return (ret);
-		node = node->right;
+		node = node->next;
 	}
 	return (EXIT_SUCCESS);
 }

--- a/src/execution/redirections.c
+++ b/src/execution/redirections.c
@@ -1,0 +1,137 @@
+#include "minishell.h"
+
+/**
+ * @brief Determine the target file descriptor for a redirection.
+ *
+ * This function inspects the given AST node's operator type to decide whether
+ * the redirection targets the standard input or output stream.
+ *
+ * @param node Pointer to the AST node representing the redirection.
+ * @return STDIN_FILENO if the redirection is an input or heredoc,
+ *         otherwise STDOUT_FILENO.
+ */
+static int	get_target_fd(t_ast *node)
+{
+	if (node->op_type == OP_INPUT || node->op_type == OP_HEREDOC)
+		return (STDIN_FILENO);
+	return (STDOUT_FILENO);
+}
+
+/**
+ * @brief Perform a file descriptor duplication for redirection.
+ *
+ * This function duplicates the provided file descriptor onto the specified
+ * target descriptor (usually STDIN or STDOUT). It also handles cleanup and
+ * error propagation. If duplication fails and the process is a child, it exits
+ * immediately with failure.
+ *
+ * @param fd The source file descriptor to duplicate.
+ * @param target_fd The target file descriptor (STDIN or STDOUT).
+ * @param node Pointer to the AST node (used for context in error handling).
+ * @param data Pointer to the main shell data structure.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
+ */
+static int	perform_dup(int, fd, int target_fd, t_ast *node, t_shell *data)
+{
+	if (dup2(fd, target_fd) == -1) //stdin now reads from fd
+	{
+		perror("dup2");
+		close(fd);
+		data->status = EXIT_FAILURE;
+		if (data->is_child)
+			exit(data->status);
+		return (data->status);
+	}
+	close(fd);
+	return (EXIT_SUCCESS);
+}
+
+/**
+ * @brief Redirect a command's standard stream based on its AST node.
+ *
+ * This function determines whether the redirection should affect STDIN or
+ * STDOUT, and then performs the appropriate duplication. It delegates the
+ * low-level duplication logic to `perform_dup()`.
+ *
+ * @param node Pointer to the AST node representing the redirection.
+ * @param data Pointer to the shell data structure for error handling.
+ * @param fd The file descriptor to redirect from/to.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
+ */
+static int	dup_redirection(t_ast *node, t_shell *data, int fd)
+{
+	int	target_fd;
+	int	result;
+
+	target_fd = get_target_fd(node);
+	result = perform_dup(fd, target_fd, node, data);
+	return (result);
+}
+
+/**
+ * @brief Apply a single redirection from an AST node.
+ *
+ * This function handles the setup of one redirection operation. It opens the
+ * target file (or uses the heredoc file descriptor) depending on the operator
+ * type, and then duplicates the resulting file descriptor to either standard
+ * input or output using `dup_redirection()`.
+ *
+ * It gracefully handles file open errors, updating the shell status and exiting
+ * immediately if the process is a child.
+ *
+ * @param node Pointer to the AST node representing the redirection.
+ * @param data Pointer to the main shell data structure.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
+ */
+static int	apply_single_redirection(t_ast *node, t_shell *data)
+{
+	int	fd;
+	int	result;
+
+	fd = -1;
+	if (node->op_type == OP_INPUT)
+		fd = open(node->filename, O_RDONLY);
+	else if (node->op_type == OP_OUTPUT)
+		fd = open(node->filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	else if (node->op_type == OP_APPEND)
+		fd = open(node->filename, O_WRONLY | O_CREAT | O_APPEND, 0644);
+	else if (node->op_type == OP_HEREDOC)
+		fd = node->heredoc_fd;
+	if (fd < 0)
+	{
+		perror(node->filename);
+		data->status = EXIT_FAILURE;
+		if (data->is_child)
+			exit(data->status);
+		return (data->status);
+	}
+	result = dup_redirection(node, data, fd);
+	return (result);
+}
+
+/**
+ * @brief Apply all redirections linked to a command node.
+ *
+ * Traverses the chain of redirection nodes (linked through the `right` pointer)
+ * and applies each one in sequence using `apply_single_redirection()`.
+ *
+ * If any redirection fails, the function immediately stops and returns
+ * `EXIT_FAILURE`, leaving subsequent redirections unapplied.
+ *
+ * @param node Pointer to the first redirection node (NODE_REDIR) in the AST.
+ * @param data Pointer to the main shell data structure.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE if any redirection fails.
+ */
+int	apply_redirections(t_ast *node, t_shell *data)
+{
+	int	ret;
+
+	while (node && node->type == NODE_REDIR)
+	{
+		ret = apply_single_redirection(node, data);
+		if (ret != EXIT_SUCCESS)
+			return (ret);
+		node = node->right;
+	}
+	return (EXIT_SUCCESS);
+}

--- a/src/parser/ast_create_nodes.c
+++ b/src/parser/ast_create_nodes.c
@@ -103,6 +103,7 @@ t_ast	*create_redir_node(t_token *op_token, t_token *file_token)
 	node->filename = ft_strdup(file_token->value);
 	if (!node->filename)
 		return (free(node->value), free(node), NULL);
+	node->heredoc_fd = -1;
 	node->left = NULL;
 	node->right = NULL;
 	node->next = NULL;
@@ -132,6 +133,7 @@ t_ast	*create_cmd_node(char **argv)
 		return (free(node), NULL);
 	node->argv = argv;
 	node->filename = NULL;
+	node->heredoc_fd = -1;
 	node->left = NULL;
 	node->right = NULL;
 	node->next = NULL;
@@ -161,6 +163,7 @@ t_ast	*create_pipe_node(t_ast *left, t_ast *right)
 		return (free(node), NULL);
 	node->argv = NULL;
 	node->filename = NULL;
+	node->heredoc_fd = -1;
 	node->left = left;
 	node->right = right;
 	node->next = NULL;

--- a/src/parser/ast_free.c
+++ b/src/parser/ast_free.c
@@ -10,7 +10,7 @@
  *
  * @param node Pointer to the AST node whose strings will be freed.
  */
-void	free_strings_in_node(t_ast *node)
+void	cleanup_node(t_ast *node)
 {
 	if (node->value)
 		free(node->value);
@@ -18,6 +18,9 @@ void	free_strings_in_node(t_ast *node)
 		free(node->filename);
 	if (node->argv)
 		free_strings_array(node->argv);
+	// Close heredoc FD if still valid
+	if (node->heredoc_fd >= 0)
+		close_fds(&node->heredoc_fd);
 }
 
 /**
@@ -37,7 +40,6 @@ void	free_ast(t_ast *node)
 
 	if (!node)
 		return ;
-	free_strings_in_node(node);
 	if (node->left)
 		free_ast(node->left);
 	if (node->type == NODE_PIPE)
@@ -55,5 +57,7 @@ void	free_ast(t_ast *node)
 			curr = next;
 		}
 	}
+	// free nodes string resources and fds
+	cleanup_node(node);
 	free(node);
 }

--- a/src/parser/ast_print.c
+++ b/src/parser/ast_print.c
@@ -96,6 +96,8 @@ void print_ast(t_ast *node, int depth)
     print_indent(depth);
     printf("│  Filename: %s\n", node->filename ? node->filename : "NULL");
     
+    print_indent(depth);
+    printf("│  heredoc_fd: %d\n", node->heredoc_fd);
     // Print redirections chain if this is a CMD node
     if (node->type == NODE_CMD && node->right)
     {

--- a/src/utils/memory_cleanup.c
+++ b/src/utils/memory_cleanup.c
@@ -65,7 +65,7 @@ void	cleanup_line(char **tokens,
 	}
 	if (ast)
 	{
-		close_all_heredocs(ast);
+		//close_all_heredocs(ast);
 		free_ast(ast);
 		ast = NULL;
 	}

--- a/src/utils/memory_cleanup.c
+++ b/src/utils/memory_cleanup.c
@@ -65,6 +65,7 @@ void	cleanup_line(char **tokens,
 	}
 	if (ast)
 	{
+		close_all_heredocs(ast);
 		free_ast(ast);
 		ast = NULL;
 	}


### PR DESCRIPTION
This PR introduces a fully functional command execution engine for the minishell project, including pipelines, builtins, external commands, and redirections. It centralizes execution logic in execute_ast_tree() and ensures proper handling of forking, parent shell state, and heredocs.

Key Features and Changes:

execute_ast_tree()

Centralized function for executing AST nodes recursively.

Handles pipelines (NODE_PIPE), forking/non-forking builtins, and external commands.

Applies redirections before command execution.

Determines when to fork based on command type and shell state.

Forking and Builtin Handling

should_fork() determines if a command requires a child process.

Non-forking builtins (cd, export, unset, exit) execute in the parent to modify shell state.

Forkable builtins and external commands run in child processes via execute_in_child_process().

Child processes handle redirections and execute the command, while the parent waits and updates data->status.

Redirections

apply_redirections() traverses all redirection nodes (NODE_REDIR) and applies them sequentially.

apply_single_redirection() handles opening files for:

OP_INPUT → read-only input

OP_OUTPUT → overwrite output file (creates if missing)

OP_APPEND → append output (creates if missing)

OP_HEREDOC → read from heredoc file descriptor

Low-level duplication handled by dup_redirection() and perform_dup().

All redirections properly redirect stdin/stdout as needed.

Builtins

execute_builtin() now returns int exit status rather than bool.

Builtin functions take argv and t_shell *data for consistent execution.

Added helper functions: is_builtin() and is_nonforking_builtin().

External Commands

execute_external_command() signature updated to accept argv instead of raw tokens.

Consistent execution with proper redirections in child processes.

Pipelines

execute_pipeline() forks left and right child processes.

Left child writes to pipe, right child reads from pipe.

wait_pipeline() ensures both children are waited for, and data->status is updated.

Heredoc Handling

Prepared in the parent process before execution.

Content written to temporary file or pipe, then heredoc_fd used in redirections.